### PR TITLE
Configure Jitsi Meet to run behind hardware nat firewall

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,9 @@ jitsi_meet_install_recommends: no
 # If (jitsi_meet_install_recommends == no), there won't be turnserver installed and available
 jitsi_meet_use_stun_turn: 'false'
 
+# Enable the p2p mode
+jitsi_meet_enable_p2p_mode: true
+
 # The STUN servers that will be used in the peer to peer connections
 jitsi_meet_stun_servers:
   - 'stun:meet-jit-si-turnrelay.jitsi.net:443'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,10 +21,10 @@ jitsi_meet_server_name: "{{ ansible_fqdn | default('localhost') }}"
 jitsi_meet_install_recommends: no
 
 # If (jitsi_meet_install_recommends == no), there won't be turnserver installed and available
-jitsi_meet_use_stun_turn: 'false'
+jitsi_meet_use_stun_turn: false
 
 # Enable the p2p mode
-jitsi_meet_enable_p2p_mode: 'true'
+jitsi_meet_enable_p2p_mode: true
 
 # The STUN servers that will be used in the peer to peer connections
 jitsi_meet_stun_servers:
@@ -120,6 +120,13 @@ jitsi_meet_debconf_settings:
 # This role will automatically install configure ufw with jitsi-meet port holes.
 # If you're managing a firewall elsewise, set this to false, and ufw will be skipped.
 jitsi_meet_configure_firewall: true
+
+#######################
+### Other firewall ###
+# This will configure NATed connection to jitsi meet
+jitsi_meet_behind_nat_firewall: false
+jitsi_meet_nat_private_ip: 127.0.0.1
+jitsi_meet_nat_public_ip: 255.255.255.255
 
 ##############
 ### Jicofo ###

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ jitsi_meet_install_recommends: no
 jitsi_meet_use_stun_turn: 'false'
 
 # Enable the p2p mode
-jitsi_meet_enable_p2p_mode: true
+jitsi_meet_enable_p2p_mode: 'true'
 
 # The STUN servers that will be used in the peer to peer connections
 jitsi_meet_stun_servers:

--- a/templates/jicofo_sip-communicator.properties.j2
+++ b/templates/jicofo_sip-communicator.properties.j2
@@ -1,2 +1,3 @@
 org.jitsi.jicofo.BRIDGE_MUC=JvbBrewery@internal.auth.{{ jitsi_meet_server_name }}
 org.jitsi.jicofo.ALWAYS_TRUST_MODE_ENABLED=true
+org.jitsi.jicofo.auth.URL=XMPP:{{ jitsi_meet_server_name }}

--- a/templates/jitsi_meet_config.js.j2
+++ b/templates/jitsi_meet_config.js.j2
@@ -350,7 +350,7 @@ var config = {
         // through the JVB and use the peer to peer connection instead. When a
         // 3rd participant joins the conference will be moved back to the JVB
         // connection.
-        enabled: true,
+        enabled: {{ jitsi_meet_enable_p2p_mode }},
 
         // Use XEP-0215 to fetch STUN and TURN servers.
         useStunTurn: {{ jitsi_meet_use_stun_turn }},

--- a/templates/jitsi_meet_config.js.j2
+++ b/templates/jitsi_meet_config.js.j2
@@ -250,7 +250,7 @@ var config = {
     // minParticipants: 2,
 
     // Use XEP-0215 to fetch STUN and TURN servers.
-    useStunTurn: {{ jitsi_meet_use_stun_turn }},
+    useStunTurn: {{ jitsi_meet_use_stun_turn | to_json}},
 
     // Enable IPv6 support.
     {% if(not jitsi_meet_ipv6_enable) %}// {% endif%}useIPv6: true,
@@ -350,10 +350,10 @@ var config = {
         // through the JVB and use the peer to peer connection instead. When a
         // 3rd participant joins the conference will be moved back to the JVB
         // connection.
-        enabled: {{ jitsi_meet_enable_p2p_mode }},
+        enabled: {{ jitsi_meet_enable_p2p_mode | to_json }},
 
         // Use XEP-0215 to fetch STUN and TURN servers.
-        useStunTurn: {{ jitsi_meet_use_stun_turn }},
+        useStunTurn: {{ jitsi_meet_use_stun_turn | to_json}},
 
         // The STUN servers that will be used in the peer to peer connections
         stunServers: [

--- a/templates/videobridge_sip-communicator.properties.j2
+++ b/templates/videobridge_sip-communicator.properties.j2
@@ -1,6 +1,6 @@
 org.ice4j.ice.harvest.DISABLE_AWS_HARVESTER=true
-org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES=meet-jit-si-turnrelay.jitsi.net:443
-org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP=focus@auth.{{ jitsi_meet_server_name }}/.*
+org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES={{ (jitsi_meet_use_stun_turn) | ternary('meet-jit-si-turnrelay.jitsi.net:443', '') }}
+{{ (jitsi_meet_behind_nat_firewall) | ternary('#', '') }}org.jitsi.videobridge.AUTHORIZED_SOURCE_REGEXP=focus@auth.{{ jitsi_meet_server_name }}/.*
 org.jitsi.videobridge.ENABLE_STATISTICS=true
 org.jitsi.videobridge.STATISTICS_TRANSPORT=muc
 org.jitsi.videobridge.xmpp.user.shard.HOSTNAME=localhost
@@ -10,3 +10,7 @@ org.jitsi.videobridge.xmpp.user.shard.PASSWORD={{ jitsi_meet_videobridge_secret 
 org.jitsi.videobridge.xmpp.user.shard.MUC_JIDS=JvbBrewery@internal.auth.{{ jitsi_meet_server_name }}
 org.jitsi.videobridge.xmpp.user.shard.MUC_NICKNAME=52eaf948-9d6c-436f-bf63-80f7a31444c2
 
+{% if jitsi_meet_behind_nat_firewall -%}
+org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS={{ jitsi_meet_nat_private_ip }}
+org.ice4j.ice.harvest.NAT_HARVESTER_PUBLIC_ADDRESS={{ jitsi_meet_nat_public_ip }}
+{%- endif %}


### PR DESCRIPTION
I added some improvements and configuration options that are needed to set up jitsi meet behind a hardware firewall with NAT enabled.