### PR TITLE
Enable change of jitsi_meet_authentication

### DIFF
--- a/tasks/jicofo.yml
+++ b/tasks/jicofo.yml
@@ -16,3 +16,11 @@
     line: ".level={{ jitsi_meet_jicofo_loglevel }}"
     state: present
   notify: restart jicofo
+
+- name: jicofo sip-communicator properties
+  become: yes
+  template:
+    src: "{{ jitsi_meet_jigasi_jicofo_sip_template }}"
+    dest: /etc/jitsi/jicofo/sip-communicator.properties
+    mode: 0644
+  notify: restart jicofo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,8 @@
 
 - include: jicofo.yml
 
+- include: prosody.yml
+
 - include: sip_gateway.yml
   when: jitsi_meet_configure_sip_gateway  | bool
 

--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -1,0 +1,18 @@
+- name: set prosody authentification
+  replace:
+    path: "/etc/prosody/conf.avail/{{ jitsi_meet_server_name }}.cfg.lua"
+    regexp: "(VirtualHost \"{{ jitsi_meet_server_name }}\"\n *--.*\n *)authentication = .*\n"
+    replace: "\\1authentication = \"{{ jitsi_meet_authentication }}\"\n"
+  tags: jitsi-prosody
+  notify: restart prosody
+- name: set guest vhost
+  blockinfile:
+    path: "/etc/prosody/conf.avail/{{ jitsi_meet_server_name }}.cfg.lua"
+    insertbefore: "Component \"focus.{{ jitsi_meet_server_name }}\""
+    marker: "-- Ansible managed block {mark}"
+    block: |
+      VirtualHost "guest.{{ jitsi_meet_server_name }}"
+          authentication = "anonymous"
+          c2s_require_encryption = false
+  tags: jitsi-prosody
+  notify: restart prosody

--- a/tasks/sip_gateway.yml
+++ b/tasks/sip_gateway.yml
@@ -21,13 +21,6 @@
       value: "{{ jitsi_meet_jigasi_password }}"
       vtype: string
 
-- name: jicofo sip-communicator properties
-  become: yes
-  template:
-    src: "{{ jitsi_meet_jigasi_jicofo_sip_template }}"
-    dest: /etc/jitsi/jicofo/sip-communicator.properties
-    mode: 0644
-  notify: restart jicofo
 
 - name: Add videobridge sip-communicator config
   template:

--- a/templates/jicofo_sip-communicator.properties.j2
+++ b/templates/jicofo_sip-communicator.properties.j2
@@ -1,2 +1,5 @@
 org.jitsi.jicofo.BRIDGE_MUC=JvbBrewery@internal.auth.{{ jitsi_meet_server_name }}
 org.jitsi.jicofo.ALWAYS_TRUST_MODE_ENABLED=true
+{% if jitsi_meet_authentication != 'anonymous' %}
+org.jitsi.jicofo.auth.URL=XMPP:{{ jitsi_meet_server_name }}
+{% endif %}

--- a/templates/jitsi_meet_config.js.j2
+++ b/templates/jitsi_meet_config.js.j2
@@ -19,10 +19,11 @@ var config = {
         domain: '{{ jitsi_meet_server_name }}',
 
         // XMPP MUC domain. FIXME: use XEP-0030 to discover it.
-        muc: 'conference.{{ jitsi_meet_server_name }}'
+        muc: 'conference.{{ jitsi_meet_server_name }}',
 
         // When using authentication, domain for guest users.
-        // anonymousdomain: 'guest.example.com',
+
+        {% if jitsi_meet_authentication == 'anonymous' %}// {% endif %}anonymousdomain: 'guest.{{ jitsi_meet_server_name }}',
 
         // Domain for authenticated users. Defaults to <domain>.
         // authdomain: '{{ jitsi_meet_server_name }}',


### PR DESCRIPTION
tested with value: **cyrus** and value: **internal_plain**

For *cyrus* on Debian Buster you will need a backprorted version of  lua-cyrussasl I dont know if we want to intergate this into the role? 